### PR TITLE
[Vulnerability] Update Axios to newer version 1.7.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "@tailwindcss/forms": "^0.5.3",
                 "@vitejs/plugin-vue": "^5.0.0",
                 "autoprefixer": "^10.4.12",
-                "axios": "^1.7.2",
+                "axios": "^1.7.4",
                 "laravel-vite-plugin": "^1.0",
                 "postcss": "^8.4.31",
                 "tailwindcss": "^3.2.1",
@@ -971,9 +971,9 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-            "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+            "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
             "dev": true,
             "dependencies": {
                 "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "@tailwindcss/forms": "^0.5.3",
         "@vitejs/plugin-vue": "^5.0.0",
         "autoprefixer": "^10.4.12",
-        "axios": "^1.7.2",
+        "axios": "^1.7.4",
         "laravel-vite-plugin": "^1.0",
         "postcss": "^8.4.31",
         "tailwindcss": "^3.2.1",


### PR DESCRIPTION
Update Axios to version 1.7.4 because of SSRF vulnerability in between versions **>= 1.3.2, <= 1.7.3**